### PR TITLE
バージョン固定により安定的に起動できるように変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,5 +17,5 @@
       ]
     }
   },
-  "postStartCommand": "pip install -r requirements.txt"
+  "postStartCommand": "pip install -r requirements.lock"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest as base
+FROM python:3.11.9-bullseye as base
 
 ARG USERNAME=pyuser
 ARG USER_UID=1000

--- a/graph_agent.py
+++ b/graph_agent.py
@@ -15,8 +15,7 @@ from typing import TypedDict, Annotated, Sequence
 
 
 # 使用するモデルを選択。
-# 予算が許す場合はgpt-4oを推奨
-MODEL = "gpt-3.5-turbo-0125"
+MODEL = "gpt-4o-mini"
 # MODEL = "gpt-4o"
 
 

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ async def on_message(msg: cl.Message):
     attachment_file_text = ""
 
     for element in msg.elements:
-        attachment_file_text += f"- {element.name} (path: {element.path.replace("/workspace", ".")})\n" # agentが参照するときは./files/***/***.pngのようになるので、それに合わせる
+        attachment_file_text += f'- {element.name} (path: {element.path.replace("/workspace", ".")})\n' # agentが参照するときは./files/***/***.pngのようになるので、それに合わせる
     
     content = msg.content
     
@@ -56,7 +56,7 @@ async def on_message(msg: cl.Message):
                 # agentノードの場合は、function callの場合は、関数名と引数を表示
                 elif hasattr(message, "additional_kwargs") and message.additional_kwargs:
                     step_name = edge_name
-                    step_output = f"function call: {message.additional_kwargs["function_call"]["name"]}\n\n```\n{message.additional_kwargs["function_call"]["arguments"]}\n```"
+                    step_output = f'function call: {message.additional_kwargs["function_call"]["name"]}\n\n```\n{message.additional_kwargs["function_call"]["arguments"]}\n```'
                 
                 # その他のパターンではとりあえず何も表示しない
                 else:


### PR DESCRIPTION
- Pythonバージョンを `3.11.9-bullseye` に固定
- devcontainerで、 `requirements.lock` を使用するように変更
- 使用モデルをgpt-4o-miniに変更

関連issue #5 